### PR TITLE
Add button dropdown to RemapButtonDialog

### DIFF
--- a/app/src/main/java/de/langerhans/odintools/ui/composables/Preferences.kt
+++ b/app/src/main/java/de/langerhans/odintools/ui/composables/Preferences.kt
@@ -311,8 +311,34 @@ fun VibrationPreferenceDialog(initialValue: Int, onCancel: () -> Unit, onSave: (
 @Composable
 fun RemapButtonDialog(initialValue: Int, onCancel: () -> Unit, onReset: () -> Unit, onSave: (newValue: Int) -> Unit) {
     val focusRequester = remember { FocusRequester() }
-    var userValue: Int by remember {
-        mutableIntStateOf(initialValue)
+    var userValue: Int by remember { mutableIntStateOf(initialValue) }
+
+    val keyCodeList = listOf(
+        KeyEvent.KEYCODE_BUTTON_A to stringResource(id = R.string.keyA),
+        KeyEvent.KEYCODE_BUTTON_B to stringResource(id = R.string.keyB),
+        KeyEvent.KEYCODE_BUTTON_C to stringResource(id = R.string.keyC),
+        KeyEvent.KEYCODE_BUTTON_X to stringResource(id = R.string.keyX),
+        KeyEvent.KEYCODE_BUTTON_Y to stringResource(id = R.string.keyY),
+        KeyEvent.KEYCODE_BUTTON_Z to stringResource(id = R.string.keyZ),
+        KeyEvent.KEYCODE_BUTTON_L1 to stringResource(id = R.string.keyL1),
+        KeyEvent.KEYCODE_BUTTON_L2 to stringResource(id = R.string.keyL2),
+        KeyEvent.KEYCODE_BUTTON_THUMBL to stringResource(id = R.string.keyL3),
+        KeyEvent.KEYCODE_BUTTON_R1 to stringResource(id = R.string.keyR1),
+        KeyEvent.KEYCODE_BUTTON_R2 to stringResource(id = R.string.keyR2),
+        KeyEvent.KEYCODE_BUTTON_THUMBR to stringResource(id = R.string.keyR3),
+        KeyEvent.KEYCODE_BUTTON_START to stringResource(id = R.string.keyStart),
+        KeyEvent.KEYCODE_BUTTON_SELECT to stringResource(id = R.string.keySelect),
+        KeyEvent.KEYCODE_BUTTON_MODE to stringResource(id = R.string.keyMode),
+        KeyEvent.KEYCODE_DPAD_UP to stringResource(id = R.string.keyDPadUp),
+        KeyEvent.KEYCODE_DPAD_DOWN to stringResource(id = R.string.keyDPadDown),
+        KeyEvent.KEYCODE_DPAD_LEFT to stringResource(id = R.string.keyDPadLeft),
+        KeyEvent.KEYCODE_DPAD_RIGHT to stringResource(id = R.string.keyDPadRight),
+        KeyEvent.KEYCODE_BACK to stringResource(id = R.string.keyBack),
+        KeyEvent.KEYCODE_HOME to stringResource(id = R.string.keyHome),
+        KeyEvent.KEYCODE_MENU to stringResource(id = R.string.keyMenu),
+    )
+    val keyCodeToStringList = keyCodeList.map { (code, resource) ->
+        KeyEvent.keyCodeToString(code) to resource
     }
 
     Dialog(onDismissRequest = {}) {
@@ -349,10 +375,13 @@ fun RemapButtonDialog(initialValue: Int, onCancel: () -> Unit, onReset: () -> Un
                     text = stringResource(id = R.string.pressAnyButton),
                     style = MaterialTheme.typography.labelLarge,
                 )
-                Text(
-                    text = KeyEvent.keyCodeToString(userValue),
-                    style = MaterialTheme.typography.bodyLarge,
-                )
+                SpinnerDialogPreference(
+                    label = R.string.selectButton,
+                    items = keyCodeToStringList,
+                    selectedKey = KeyEvent.keyCodeToString(userValue),
+                ) {
+                    userValue = KeyEvent.keyCodeFromString(it)
+                }
                 Spacer(modifier = Modifier.padding(12.dp))
                 // Buttons
                 Row(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -70,7 +70,8 @@
     <string name="remapButtonDescription">Remap button to another key code</string>
     <string name="m1Button">M1 button</string>
     <string name="m2Button">M2 button</string>
-    <string name="pressAnyButton">Press any button</string>
+    <string name="pressAnyButton">Press any button or…</string>
+    <string name="selectButton">Select button</string>
     <string name="setDefault">Set Default</string>
 
     <string name="battery">Battery</string>
@@ -85,4 +86,27 @@
     <string name="debug">Debug</string>
     <string name="dumpLogToFile">Dump log to file</string>
     <string name="dumpLogToFileDescription">Dump log output to a text file in the internal memory.</string>
+
+    <string name="keyA">A Button</string>
+    <string name="keyB">B Button</string>
+    <string name="keyC">C Button</string>
+    <string name="keyX">X Button</string>
+    <string name="keyY">Y Button</string>
+    <string name="keyZ">Z Button</string>
+    <string name="keyL1">L1 Button</string>
+    <string name="keyL2">L2 Button</string>
+    <string name="keyL3">Left Stick Button</string>
+    <string name="keyR1">R1 Button</string>
+    <string name="keyR2">R2 Button</string>
+    <string name="keyR3">Right Stick Button</string>
+    <string name="keyDPadUp">D-Pad Up</string>
+    <string name="keyDPadDown">D-Pad Down</string>
+    <string name="keyDPadLeft">D-Pad Left</string>
+    <string name="keyDPadRight">D-Pad Right</string>
+    <string name="keyStart">Start</string>
+    <string name="keySelect">Select</string>
+    <string name="keyBack">Back</string>
+    <string name="keyHome">Home</string>
+    <string name="keyMode">Guide</string>
+    <string name="keyMenu">Menu</string>
 </resources>


### PR DESCRIPTION
Add a simple drop-down to manually select the button to remap to as an alternative to the "Press any button" feature.

![Screenshot_20241025-003422](https://github.com/user-attachments/assets/a6536b22-2a11-42d1-815d-749e83d68bf5)
![Screenshot_20241025-003537](https://github.com/user-attachments/assets/8d4b922d-67c5-4f45-b60b-bd7866c5f86b)
