### PR TITLE
Fix display saturation breaking on non-US locales

### DIFF
--- a/app/src/main/java/de/langerhans/odintools/tools/SettingsRepo.kt
+++ b/app/src/main/java/de/langerhans/odintools/tools/SettingsRepo.kt
@@ -1,6 +1,7 @@
 package de.langerhans.odintools.tools
 
 import de.langerhans.odintools.BuildConfig
+import java.util.Locale
 import javax.inject.Inject
 
 class SettingsRepo @Inject constructor(
@@ -42,7 +43,7 @@ class SettingsRepo @Inject constructor(
     }
 
     fun setSfSaturation(value: Float) {
-        executor.executeAsRoot("service call SurfaceFlinger 1022 f ${String.format("%.1f", value)}")
+        executor.executeAsRoot("service call SurfaceFlinger 1022 f ${String.format(Locale.US, "%.1f", value)}")
     }
 
     fun enableChargingSeparation() {


### PR DESCRIPTION
## Problem

`SettingsRepo.setSfSaturation` builds the SurfaceFlinger command using `String.format("%.1f", value)` without an explicit `Locale`. On devices whose locale uses a comma as the decimal separator (Spanish, German, French, etc.), a value like `0.9` is formatted as `"0,9"`.

This produces an invalid call:

```
service call SurfaceFlinger 1022 f 0,9
```

The result is that the display turns **black & white** instead of applying the intended saturation. I hit this on an Odin 2 with the system language set to Spanish.

## Fix

Pass `Locale.US` to `String.format` so the decimal separator is always a dot, regardless of the device language. One-line change plus the import.

## Testing

Tested on an Odin 2 with the system locale set to Spanish: saturation values like `0.9` now apply correctly instead of dropping to grayscale.